### PR TITLE
Output Windows Error code and message on command failure

### DIFF
--- a/wtrace/ProcessCreator.cs
+++ b/wtrace/ProcessCreator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Diagnostics.Tracing.Parsers.AspNet;
 using WinHandles = VsChromium.Core.Win32.Handles;
@@ -31,7 +32,7 @@ namespace LowLevelDesign.WinTrace
 
             if (!WinProcesses.NativeMethods.CreateProcess(null, new StringBuilder(string.Join(" ", args)), null, null, false,
                         processCreationFlags, null, null, si, pi)) {
-                throw new Win32Exception("Error while creating a new process.");
+                throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 
             hProcess = new WinProcesses.SafeProcessHandle(pi.hProcess);

--- a/wtrace/Program.cs
+++ b/wtrace/Program.cs
@@ -98,7 +98,7 @@ namespace LowLevelDesign.WinTrace
             }
             catch (Win32Exception ex) {
                 Console.Error.WriteLine(
-                    $"ERROR: an error occurred while trying to start or open the process, code: 0x{ex.HResult:X}");
+                    $"ERROR: an error occurred while trying to start or open the process, code: 0x{ex.HResult:X}\nErrorCode: 0x{ex.NativeErrorCode:X8}: {ex.Message}." );
             }
             catch (Exception ex) {
                 Console.Error.WriteLine($"ERROR: severe error happened when starting application: {ex.Message}");


### PR DESCRIPTION
Write the Win32ErrorCode and localized error message from Windows to `stderr` when
CreateProcess fails.

Before:
```
wtrace.exe NonExistent
ERROR: an error occurred while trying to start or open the process, code: 0x80004005
```

After:
```
wtrace.exe NonExistent
ERROR: an error occurred while trying to start or open the process, code: 0x80004005
ErrorCode: 0x00000002: The system cannot find the file specified.
```

Available error codes are listed here: https://msdn.microsoft.com/en-us/library/cc231199.aspx